### PR TITLE
fix: Correct Tower job listing date from 2024 to 2025

### DIFF
--- a/data/jobs.json
+++ b/data/jobs.json
@@ -4,7 +4,7 @@
     "posted_by": "Kunal Kapila",
     "company": "Tower Research Capital",
     "location": "Hong Kong / London / Gurgaon",
-    "date": "2024-06-24",
+    "date": "2025-06-24",
     "description": "My team at Tower Research Capital is looking for Software Engineers, preferably with a C++ background, and 2-5yrs of experience. Location preference: Hong Kong / London (can do Gurgaon if the person has strong preference for staying in India)"
   },
   {


### PR DESCRIPTION
Updated the date for Tower Research Capital job listing from 2024-06-24 to 2025-06-24 to reflect the correct year.

🤖 Generated with [Claude Code](https://claude.ai/code)